### PR TITLE
Netlify domain redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,4 @@
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-  force = false
-
-[[redirects]]
   from = "/"
   to = "https://sourav.ca"
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,8 @@
   to = "/index.html"
   status = 200
   force = false
+
+[[redirects]]
+  from = "/"
+  to = "https://sourav.ca"
+  force = true


### PR DESCRIPTION
I had [https://know-sourav.netlify.app](https://know-sourav.netlify.app) as the portfolio URL in my resumes, but now the website is hosted on [https://sourav.ca](https://sourav.ca) and the backend don't allow [https://know-sourav.netlify.app](https://know-sourav.netlify.app) to access the API, therefore added redirect rule in netlify.toml file to redirect all visitors to be redirected to [https://sourav.ca](https://sourav.ca) 